### PR TITLE
[Fix] Run only the saveCache() on post step if cache argument is true

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,4 +26,4 @@ inputs:
 runs:
   using: 'node16'
   main: 'dist/setup/index.js'
-#  post: 'dist/cleanup/index.js'
+  post: 'dist/cleanup/index.js'

--- a/action.yml
+++ b/action.yml
@@ -26,4 +26,4 @@ inputs:
 runs:
   using: 'node16'
   main: 'dist/setup/index.js'
-  post: 'dist/cleanup/index.js'
+#  post: 'dist/cleanup/index.js'

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -59333,10 +59333,11 @@ function run() {
             const ndkVersion = core.getInput(constants.INPUT_NDK_VERSION);
             const cmakeVersion = core.getInput(constants.INPUT_CMAKE_VERSION);
             const cacheDisabled = core.getInput(constants.INPUT_CACHE_DISABLED);
+            let savedCacheEntry;
             if (!cacheDisabled) {
-                const savedCacheEntry = yield (0, cache_1.saveCache)(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion);
-                yield (0, summary_1.renderSummary)(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion, savedCacheEntry);
+                savedCacheEntry = yield (0, cache_1.saveCache)(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion);
             }
+            yield (0, summary_1.renderSummary)(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion, savedCacheEntry);
         }
         catch (error) {
             if (error instanceof Error)

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -59332,8 +59332,11 @@ function run() {
             const buildToolsVersion = core.getInput(constants.INPUT_BUILD_TOOLS_VERSION);
             const ndkVersion = core.getInput(constants.INPUT_NDK_VERSION);
             const cmakeVersion = core.getInput(constants.INPUT_CMAKE_VERSION);
-            const savedCacheEntry = yield (0, cache_1.saveCache)(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion);
-            yield (0, summary_1.renderSummary)(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion, savedCacheEntry);
+            const cacheDisabled = core.getInput(constants.INPUT_CACHE_DISABLED);
+            if (!cacheDisabled) {
+                const savedCacheEntry = yield (0, cache_1.saveCache)(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion);
+                yield (0, summary_1.renderSummary)(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion, savedCacheEntry);
+            }
         }
         catch (error) {
             if (error instanceof Error)

--- a/src/cleanup-android.ts
+++ b/src/cleanup-android.ts
@@ -14,20 +14,23 @@ async function run(): Promise<void> {
     const buildToolsVersion = core.getInput(constants.INPUT_BUILD_TOOLS_VERSION)
     const ndkVersion = core.getInput(constants.INPUT_NDK_VERSION)
     const cmakeVersion = core.getInput(constants.INPUT_CMAKE_VERSION)
+    const cacheDisabled = core.getInput(constants.INPUT_CACHE_DISABLED)
 
-    const savedCacheEntry = await saveCache(
-      sdkVersion,
-      buildToolsVersion,
-      ndkVersion,
-      cmakeVersion
-    )
-    await renderSummary(
-      sdkVersion,
-      buildToolsVersion,
-      ndkVersion,
-      cmakeVersion,
-      savedCacheEntry
-    )
+    if (!cacheDisabled) {
+      const savedCacheEntry = await saveCache(
+        sdkVersion,
+        buildToolsVersion,
+        ndkVersion,
+        cmakeVersion
+      )
+      await renderSummary(
+        sdkVersion,
+        buildToolsVersion,
+        ndkVersion,
+        cmakeVersion,
+        savedCacheEntry
+      )
+    }
   } catch (error) {
     if (error instanceof Error) core.setFailed(error.message)
   }

--- a/src/cleanup-android.ts
+++ b/src/cleanup-android.ts
@@ -16,21 +16,23 @@ async function run(): Promise<void> {
     const cmakeVersion = core.getInput(constants.INPUT_CMAKE_VERSION)
     const cacheDisabled = core.getInput(constants.INPUT_CACHE_DISABLED)
 
+    let savedCacheEntry
     if (!cacheDisabled) {
-      const savedCacheEntry = await saveCache(
+      savedCacheEntry = await saveCache(
         sdkVersion,
         buildToolsVersion,
         ndkVersion,
         cmakeVersion
       )
-      await renderSummary(
-        sdkVersion,
-        buildToolsVersion,
-        ndkVersion,
-        cmakeVersion,
-        savedCacheEntry
-      )
     }
+
+    await renderSummary(
+      sdkVersion,
+      buildToolsVersion,
+      ndkVersion,
+      cmakeVersion,
+      savedCacheEntry
+    )
   } catch (error) {
     if (error instanceof Error) core.setFailed(error.message)
   }


### PR DESCRIPTION
 Issue: Closes [https://github.com/amyu/setup-android/issues/25](https://github.com/amyu/setup-android/issues/25) 

**Current Problem:**
Even if we pass the action argument `cache-disabled` to `true`, the current implementation is always saving the cache at the post step (taking a lot of time to save it). 
<img width="815" alt="disabled_cache_post_step" src="https://user-images.githubusercontent.com/12532273/223465866-7282388d-fdf1-4f25-9e45-61c6c64f7b9f.png">

**This PR solution:**
Run only the saveCache function if `cacheDisabled` is `false` (basically only run saveCache if we are using cache).
<img width="639" alt="disabled_cache_post_step_fix" src="https://user-images.githubusercontent.com/12532273/223467144-1c4464c4-1f76-4196-b17f-5e36556295cd.png">

