### PR TITLE
[Fix] Add optional `generate-job-summary` input to input parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ steps:
       # Installed when the version is specified
       ndk-version: '23.1.7779620'
 
+      # default: true
+      # Whether to generate or not the job summary     
+      generate-job-summary: false
+
   - run: ./gradlew build --stacktrace
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
     required: false
     description: 'disabled cache'
     default: 'false'
-  display-summary:
+  generate-job-summary:
     required: false
     description: 'display job summary'
     default: 'true'

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,10 @@ inputs:
     required: false
     description: 'disabled cache'
     default: 'false'
+  display-summary:
+    required: false
+    description: 'display job summary'
+    default: 'true'
   job-status:
     description: 'Workaround to pass job status to post job step. This variable is not intended for manual setting'
     default: ${{ job.status }}

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -59332,8 +59332,10 @@ function run() {
             const buildToolsVersion = core.getInput(constants.INPUT_BUILD_TOOLS_VERSION);
             const ndkVersion = core.getInput(constants.INPUT_NDK_VERSION);
             const cmakeVersion = core.getInput(constants.INPUT_CMAKE_VERSION);
-            const cacheDisabled = core.getInput(constants.INPUT_CACHE_DISABLED);
-            const generateJobSummary = core.getInput(constants.INPUT_GENERATE_JOB_SUMMARY);
+            const cacheDisabled = core.getBooleanInput(constants.INPUT_CACHE_DISABLED);
+            const generateJobSummary = core.getBooleanInput(constants.INPUT_GENERATE_JOB_SUMMARY);
+            core.info(`cache-disabled: ${cacheDisabled}`);
+            core.info(`generate-job-summary: ${generateJobSummary}`);
             let savedCacheEntry;
             if (!cacheDisabled) {
                 savedCacheEntry = yield (0, cache_1.saveCache)(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion);

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -59333,11 +59333,14 @@ function run() {
             const ndkVersion = core.getInput(constants.INPUT_NDK_VERSION);
             const cmakeVersion = core.getInput(constants.INPUT_CMAKE_VERSION);
             const cacheDisabled = core.getInput(constants.INPUT_CACHE_DISABLED);
+            const displayJobSummary = core.getInput(constants.INPUT_JOB_SUMMARY);
             let savedCacheEntry;
             if (!cacheDisabled) {
                 savedCacheEntry = yield (0, cache_1.saveCache)(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion);
             }
-            yield (0, summary_1.renderSummary)(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion, savedCacheEntry);
+            if (displayJobSummary) {
+                yield (0, summary_1.renderSummary)(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion, savedCacheEntry);
+            }
         }
         catch (error) {
             if (error instanceof Error)
@@ -59387,7 +59390,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.ANDROID_SDK_ROOT = exports.ANDROID_HOME_DIR = exports.HOME = exports.COMMANDLINE_TOOLS_WINDOWS_URL = exports.COMMANDLINE_TOOLS_MAC_URL = exports.COMMANDLINE_TOOLS_LINUX_URL = exports.INPUT_JOB_STATUS = exports.INPUT_CACHE_DISABLED = exports.INPUT_CMAKE_VERSION = exports.INPUT_NDK_VERSION = exports.INPUT_BUILD_TOOLS_VERSION = exports.INPUT_SDK_VERSION = void 0;
+exports.ANDROID_SDK_ROOT = exports.ANDROID_HOME_DIR = exports.HOME = exports.COMMANDLINE_TOOLS_WINDOWS_URL = exports.COMMANDLINE_TOOLS_MAC_URL = exports.COMMANDLINE_TOOLS_LINUX_URL = exports.INPUT_JOB_STATUS = exports.INPUT_JOB_SUMMARY = exports.INPUT_CACHE_DISABLED = exports.INPUT_CMAKE_VERSION = exports.INPUT_NDK_VERSION = exports.INPUT_BUILD_TOOLS_VERSION = exports.INPUT_SDK_VERSION = void 0;
 const os = __importStar(__nccwpck_require__(2037));
 const path_1 = __importDefault(__nccwpck_require__(1017));
 exports.INPUT_SDK_VERSION = 'sdk-version';
@@ -59395,6 +59398,7 @@ exports.INPUT_BUILD_TOOLS_VERSION = 'build-tools-version';
 exports.INPUT_NDK_VERSION = 'ndk-version';
 exports.INPUT_CMAKE_VERSION = 'cmake-version';
 exports.INPUT_CACHE_DISABLED = 'cache-disabled';
+exports.INPUT_JOB_SUMMARY = 'job-summary';
 exports.INPUT_JOB_STATUS = 'job-status';
 // https://developer.android.com/studio#command-tools
 exports.COMMANDLINE_TOOLS_LINUX_URL = `https://dl.google.com/android/repository/commandlinetools-linux-8512546_latest.zip`;

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -59333,12 +59333,12 @@ function run() {
             const ndkVersion = core.getInput(constants.INPUT_NDK_VERSION);
             const cmakeVersion = core.getInput(constants.INPUT_CMAKE_VERSION);
             const cacheDisabled = core.getInput(constants.INPUT_CACHE_DISABLED);
-            const displayJobSummary = core.getInput(constants.INPUT_JOB_SUMMARY);
+            const generateJobSummary = core.getInput(constants.INPUT_GENERATE_JOB_SUMMARY);
             let savedCacheEntry;
             if (!cacheDisabled) {
                 savedCacheEntry = yield (0, cache_1.saveCache)(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion);
             }
-            if (displayJobSummary) {
+            if (generateJobSummary) {
                 yield (0, summary_1.renderSummary)(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion, savedCacheEntry);
             }
         }
@@ -59390,7 +59390,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.ANDROID_SDK_ROOT = exports.ANDROID_HOME_DIR = exports.HOME = exports.COMMANDLINE_TOOLS_WINDOWS_URL = exports.COMMANDLINE_TOOLS_MAC_URL = exports.COMMANDLINE_TOOLS_LINUX_URL = exports.INPUT_JOB_STATUS = exports.INPUT_JOB_SUMMARY = exports.INPUT_CACHE_DISABLED = exports.INPUT_CMAKE_VERSION = exports.INPUT_NDK_VERSION = exports.INPUT_BUILD_TOOLS_VERSION = exports.INPUT_SDK_VERSION = void 0;
+exports.ANDROID_SDK_ROOT = exports.ANDROID_HOME_DIR = exports.HOME = exports.COMMANDLINE_TOOLS_WINDOWS_URL = exports.COMMANDLINE_TOOLS_MAC_URL = exports.COMMANDLINE_TOOLS_LINUX_URL = exports.INPUT_JOB_STATUS = exports.INPUT_GENERATE_JOB_SUMMARY = exports.INPUT_CACHE_DISABLED = exports.INPUT_CMAKE_VERSION = exports.INPUT_NDK_VERSION = exports.INPUT_BUILD_TOOLS_VERSION = exports.INPUT_SDK_VERSION = void 0;
 const os = __importStar(__nccwpck_require__(2037));
 const path_1 = __importDefault(__nccwpck_require__(1017));
 exports.INPUT_SDK_VERSION = 'sdk-version';
@@ -59398,7 +59398,7 @@ exports.INPUT_BUILD_TOOLS_VERSION = 'build-tools-version';
 exports.INPUT_NDK_VERSION = 'ndk-version';
 exports.INPUT_CMAKE_VERSION = 'cmake-version';
 exports.INPUT_CACHE_DISABLED = 'cache-disabled';
-exports.INPUT_JOB_SUMMARY = 'job-summary';
+exports.INPUT_GENERATE_JOB_SUMMARY = 'generate-job-summary';
 exports.INPUT_JOB_STATUS = 'job-status';
 // https://developer.android.com/studio#command-tools
 exports.COMMANDLINE_TOOLS_LINUX_URL = `https://dl.google.com/android/repository/commandlinetools-linux-8512546_latest.zip`;

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -60252,7 +60252,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.ANDROID_SDK_ROOT = exports.ANDROID_HOME_DIR = exports.HOME = exports.COMMANDLINE_TOOLS_WINDOWS_URL = exports.COMMANDLINE_TOOLS_MAC_URL = exports.COMMANDLINE_TOOLS_LINUX_URL = exports.INPUT_JOB_STATUS = exports.INPUT_CACHE_DISABLED = exports.INPUT_CMAKE_VERSION = exports.INPUT_NDK_VERSION = exports.INPUT_BUILD_TOOLS_VERSION = exports.INPUT_SDK_VERSION = void 0;
+exports.ANDROID_SDK_ROOT = exports.ANDROID_HOME_DIR = exports.HOME = exports.COMMANDLINE_TOOLS_WINDOWS_URL = exports.COMMANDLINE_TOOLS_MAC_URL = exports.COMMANDLINE_TOOLS_LINUX_URL = exports.INPUT_JOB_STATUS = exports.INPUT_JOB_SUMMARY = exports.INPUT_CACHE_DISABLED = exports.INPUT_CMAKE_VERSION = exports.INPUT_NDK_VERSION = exports.INPUT_BUILD_TOOLS_VERSION = exports.INPUT_SDK_VERSION = void 0;
 const os = __importStar(__nccwpck_require__(2037));
 const path_1 = __importDefault(__nccwpck_require__(1017));
 exports.INPUT_SDK_VERSION = 'sdk-version';
@@ -60260,6 +60260,7 @@ exports.INPUT_BUILD_TOOLS_VERSION = 'build-tools-version';
 exports.INPUT_NDK_VERSION = 'ndk-version';
 exports.INPUT_CMAKE_VERSION = 'cmake-version';
 exports.INPUT_CACHE_DISABLED = 'cache-disabled';
+exports.INPUT_JOB_SUMMARY = 'job-summary';
 exports.INPUT_JOB_STATUS = 'job-status';
 // https://developer.android.com/studio#command-tools
 exports.COMMANDLINE_TOOLS_LINUX_URL = `https://dl.google.com/android/repository/commandlinetools-linux-8512546_latest.zip`;

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -60252,7 +60252,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.ANDROID_SDK_ROOT = exports.ANDROID_HOME_DIR = exports.HOME = exports.COMMANDLINE_TOOLS_WINDOWS_URL = exports.COMMANDLINE_TOOLS_MAC_URL = exports.COMMANDLINE_TOOLS_LINUX_URL = exports.INPUT_JOB_STATUS = exports.INPUT_JOB_SUMMARY = exports.INPUT_CACHE_DISABLED = exports.INPUT_CMAKE_VERSION = exports.INPUT_NDK_VERSION = exports.INPUT_BUILD_TOOLS_VERSION = exports.INPUT_SDK_VERSION = void 0;
+exports.ANDROID_SDK_ROOT = exports.ANDROID_HOME_DIR = exports.HOME = exports.COMMANDLINE_TOOLS_WINDOWS_URL = exports.COMMANDLINE_TOOLS_MAC_URL = exports.COMMANDLINE_TOOLS_LINUX_URL = exports.INPUT_JOB_STATUS = exports.INPUT_GENERATE_JOB_SUMMARY = exports.INPUT_CACHE_DISABLED = exports.INPUT_CMAKE_VERSION = exports.INPUT_NDK_VERSION = exports.INPUT_BUILD_TOOLS_VERSION = exports.INPUT_SDK_VERSION = void 0;
 const os = __importStar(__nccwpck_require__(2037));
 const path_1 = __importDefault(__nccwpck_require__(1017));
 exports.INPUT_SDK_VERSION = 'sdk-version';
@@ -60260,7 +60260,7 @@ exports.INPUT_BUILD_TOOLS_VERSION = 'build-tools-version';
 exports.INPUT_NDK_VERSION = 'ndk-version';
 exports.INPUT_CMAKE_VERSION = 'cmake-version';
 exports.INPUT_CACHE_DISABLED = 'cache-disabled';
-exports.INPUT_JOB_SUMMARY = 'job-summary';
+exports.INPUT_GENERATE_JOB_SUMMARY = 'generate-job-summary';
 exports.INPUT_JOB_STATUS = 'job-status';
 // https://developer.android.com/studio#command-tools
 exports.COMMANDLINE_TOOLS_LINUX_URL = `https://dl.google.com/android/repository/commandlinetools-linux-8512546_latest.zip`;

--- a/src/cleanup-android.ts
+++ b/src/cleanup-android.ts
@@ -15,6 +15,7 @@ async function run(): Promise<void> {
     const ndkVersion = core.getInput(constants.INPUT_NDK_VERSION)
     const cmakeVersion = core.getInput(constants.INPUT_CMAKE_VERSION)
     const cacheDisabled = core.getInput(constants.INPUT_CACHE_DISABLED)
+    const displayJobSummary = core.getInput(constants.INPUT_JOB_SUMMARY)
 
     let savedCacheEntry
     if (!cacheDisabled) {
@@ -26,13 +27,15 @@ async function run(): Promise<void> {
       )
     }
 
-    await renderSummary(
-      sdkVersion,
-      buildToolsVersion,
-      ndkVersion,
-      cmakeVersion,
-      savedCacheEntry
-    )
+    if (displayJobSummary) {
+      await renderSummary(
+        sdkVersion,
+        buildToolsVersion,
+        ndkVersion,
+        cmakeVersion,
+        savedCacheEntry
+      )
+    }
   } catch (error) {
     if (error instanceof Error) core.setFailed(error.message)
   }

--- a/src/cleanup-android.ts
+++ b/src/cleanup-android.ts
@@ -14,10 +14,13 @@ async function run(): Promise<void> {
     const buildToolsVersion = core.getInput(constants.INPUT_BUILD_TOOLS_VERSION)
     const ndkVersion = core.getInput(constants.INPUT_NDK_VERSION)
     const cmakeVersion = core.getInput(constants.INPUT_CMAKE_VERSION)
-    const cacheDisabled = core.getInput(constants.INPUT_CACHE_DISABLED)
-    const generateJobSummary = core.getInput(
+    const cacheDisabled = core.getBooleanInput(constants.INPUT_CACHE_DISABLED)
+    const generateJobSummary = core.getBooleanInput(
       constants.INPUT_GENERATE_JOB_SUMMARY
     )
+
+    core.info(`cache-disabled: ${cacheDisabled}`)
+    core.info(`generate-job-summary: ${generateJobSummary}`)
 
     let savedCacheEntry
     if (!cacheDisabled) {

--- a/src/cleanup-android.ts
+++ b/src/cleanup-android.ts
@@ -15,7 +15,9 @@ async function run(): Promise<void> {
     const ndkVersion = core.getInput(constants.INPUT_NDK_VERSION)
     const cmakeVersion = core.getInput(constants.INPUT_CMAKE_VERSION)
     const cacheDisabled = core.getInput(constants.INPUT_CACHE_DISABLED)
-    const displayJobSummary = core.getInput(constants.INPUT_JOB_SUMMARY)
+    const generateJobSummary = core.getInput(
+      constants.INPUT_GENERATE_JOB_SUMMARY
+    )
 
     let savedCacheEntry
     if (!cacheDisabled) {
@@ -27,7 +29,7 @@ async function run(): Promise<void> {
       )
     }
 
-    if (displayJobSummary) {
+    if (generateJobSummary) {
       await renderSummary(
         sdkVersion,
         buildToolsVersion,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,6 +7,7 @@ export const INPUT_NDK_VERSION = 'ndk-version'
 export const INPUT_CMAKE_VERSION = 'cmake-version'
 export const INPUT_CACHE_DISABLED = 'cache-disabled'
 
+export const INPUT_JOB_SUMMARY = 'job-summary'
 export const INPUT_JOB_STATUS = 'job-status'
 
 // https://developer.android.com/studio#command-tools

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,7 +7,7 @@ export const INPUT_NDK_VERSION = 'ndk-version'
 export const INPUT_CMAKE_VERSION = 'cmake-version'
 export const INPUT_CACHE_DISABLED = 'cache-disabled'
 
-export const INPUT_JOB_SUMMARY = 'job-summary'
+export const INPUT_GENERATE_JOB_SUMMARY = 'generate-job-summary'
 export const INPUT_JOB_STATUS = 'job-status'
 
 // https://developer.android.com/studio#command-tools


### PR DESCRIPTION
 Issue: Closes [https://github.com/amyu/setup-android/issues/27](https://github.com/amyu/setup-android/issues/27)

**Current Problem:**
This action is always posting the job summary (attached to the workflow run). This can be useful in some cases, but it also pollutes the workflow page. So it should be optional.
<img width="727" alt="job_summary" src="https://user-images.githubusercontent.com/12532273/224757572-5eef06fe-ecf3-4d1b-9c9e-0e6a6a35e699.png">


**This PR solution:**
Add an optional parameter `generate-job-summary`, and only run renderSummary() if this is `true` (`true` by default).

**Example of how to use it:**
#### If we want to display the job summary on the workflow result
```
- name: Setup Android SDK
  uses: amyu/setup-android@v2
  with:
    cache-disabled: true
    sdk-version: '31'
    build-tools-version: '30.0.2'
    ndk-version: '21.3.6528147'
```
#### If we want to hide the job summary on the workflow result
```
- name: Setup Android SDK
  uses: amyu/setup-android@v2
  with:
    cache-disabled: true
    sdk-version: '31'
    build-tools-version: '30.0.2'
    ndk-version: '21.3.6528147'
    generate-job-summary: false
```