### PR TITLE
feat: custom key for cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         sdk: [32, 33]
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-${{ matrix.sdk }}-test
@@ -52,7 +52,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-test_not_use_cache
       cancel-in-progress: true
@@ -91,7 +91,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -116,3 +116,35 @@ jobs:
 
       - run: |
           sdkmanager --install "system-images;android-31;default;x86_64"
+
+  test_custom_cache_key:
+    name: run test custom cache key
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: remove android sdk from ubuntu-latest
+        shell: bash
+        run: |
+          echo 'ANDROID_HOME=' >> $GITHUB_ENV
+          echo 'ANDROID_SDK_ROOT=' >> $GITHUB_ENV
+          rm -rf ~/android
+
+      - name: Setup JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: temurin
+
+      - name: Setup Android SDK
+        uses: ./
+        with:
+          cache-key: 'default-version'
+
+      - run: |
+          sdkmanager --install emulator

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # setup-android
 
-This action provides the following functionality for GitHub Actions users:  
+This action provides the following functionality for GitHub Actions users:
 
 - Optionally downloading and caching distribution of the requested sdk version or build tools version or ndk,cmake version, and adding it to the PATH
 - Runs on Mac, Linux and Windows powered by SelfHostedRunner
 
 # Motivation
+
 This Action is provided for SelfHostedRunner.  
 GithubHostedRunner does not need this Action as it already has the SDK set up.
 
@@ -14,6 +15,7 @@ GithubHostedRunner does not need this Action as it already has the SDK set up.
 See [action.yml](action.yml)
 
 **Basic:**
+
 ```yaml
 steps:
   - uses: actions/checkout@v4
@@ -22,7 +24,7 @@ steps:
     with:
       java-version: 17
       distribution: temurin
-      
+
   - name: Setup Android SDK
     uses: amyu/setup-android@v3
 
@@ -30,6 +32,7 @@ steps:
 ```
 
 **Additional:**
+
 ```yaml
 steps:
   - uses: actions/checkout@v4
@@ -38,26 +41,30 @@ steps:
     with:
       java-version: 17
       distribution: temurin
-      
+
   - name: Setup Android SDK
     uses: amyu/setup-android@v3
     with:
       # default: false
-      # Whether to use the cache     
+      # Whether to use the cache
       cache-disabled: true
-      
+
+      # default: `${sdkVersion}-${buildToolsVersion}-${ndkVersion}-${cmakeVersion}-v3.1`
+      # Custom key for cache. It is invalid when `cache-disabled: true`
+      cache-key: 'custom-cache-key'
+
       # default: '33'
       # sdk version
       # see https://developer.android.com/studio/releases/platforms
       # It will always be installed.
       sdk-version: '33'
-      
+
       # default: '33.0.2'
       # build tools version
       # see https://developer.android.com/studio/releases/build-tools
       # It will always be installed.
       build-tools-version: '33.0.2'
-      
+
       # default: ''
       # cmake version
       # see https://developer.android.com/studio/projects/install-ndk
@@ -71,7 +78,7 @@ steps:
       ndk-version: '23.1.7779620'
 
       # default: true
-      # Whether to generate or not the job summary     
+      # Whether to generate or not the job summary
       generate-job-summary: false
 
   - run: ./gradlew build --stacktrace

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,10 @@ inputs:
     required: false
     description: 'disabled cache'
     default: 'false'
+  cache-key:
+    required: false
+    description: 'cache key'
+    default: ''
   generate-job-summary:
     required: false
     description: 'display job summary'

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -59643,28 +59643,30 @@ const cache = __importStar(__nccwpck_require__(7799));
 const constants_1 = __nccwpck_require__(9042);
 const cache_1 = __nccwpck_require__(7799);
 const RESTORED_ENTRY_STATE_KEY = 'restoredEntry';
-function generateRestoreKey(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion) {
+function generateRestoreKey(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion, cacheKey) {
+    if (cacheKey)
+        return cacheKey;
     return `${sdkVersion}-${buildToolsVersion}-${ndkVersion}-${cmakeVersion}-v3.1`;
 }
-function restoreCache(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion) {
+function restoreCache(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion, cacheKey) {
     return __awaiter(this, void 0, void 0, function* () {
-        const restoreKey = generateRestoreKey(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion);
+        const restoreKey = generateRestoreKey(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion, cacheKey);
         const restoredEntry = yield cache.restoreCache([constants_1.ANDROID_HOME_DIR], restoreKey);
         if (restoredEntry) {
-            core.info(`Found in cache`);
+            core.info(`Found in cache: ${restoredEntry}`);
         }
         else {
-            core.info(`Not Found cache`);
+            core.info(`Not Found cache: ${restoredEntry}`);
         }
         core.saveState(RESTORED_ENTRY_STATE_KEY, restoredEntry);
         return Promise.resolve(restoredEntry);
     });
 }
 exports.restoreCache = restoreCache;
-function saveCache(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion) {
+function saveCache(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion, cacheKey) {
     return __awaiter(this, void 0, void 0, function* () {
-        const restoreKey = generateRestoreKey(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion);
-        core.info(`caching ...`);
+        const restoreKey = generateRestoreKey(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion, cacheKey);
+        core.info(`caching "${restoreKey}" ...`);
         try {
             const savedEntry = yield cache.saveCache([constants_1.ANDROID_HOME_DIR], restoreKey);
             return Promise.resolve(savedEntry);
@@ -59744,12 +59746,14 @@ function run() {
             const ndkVersion = core.getInput(constants.INPUT_NDK_VERSION);
             const cmakeVersion = core.getInput(constants.INPUT_CMAKE_VERSION);
             const cacheDisabled = core.getBooleanInput(constants.INPUT_CACHE_DISABLED);
+            const cacheKey = core.getInput(constants.INPUT_CACHE_KEY);
             const generateJobSummary = core.getBooleanInput(constants.INPUT_GENERATE_JOB_SUMMARY);
             core.info(`cache-disabled: ${cacheDisabled}`);
+            core.info(`cache-key: ${cacheKey}`);
             core.info(`generate-job-summary: ${generateJobSummary}`);
             let savedCacheEntry;
             if (!cacheDisabled) {
-                savedCacheEntry = yield (0, cache_1.saveCache)(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion);
+                savedCacheEntry = yield (0, cache_1.saveCache)(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion, cacheKey);
             }
             if (generateJobSummary) {
                 yield (0, summary_1.renderSummary)(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion, savedCacheEntry);
@@ -59803,7 +59807,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.ANDROID_SDK_ROOT = exports.ANDROID_HOME_DIR = exports.HOME = exports.COMMANDLINE_TOOLS_WINDOWS_URL = exports.COMMANDLINE_TOOLS_MAC_URL = exports.COMMANDLINE_TOOLS_LINUX_URL = exports.INPUT_JOB_STATUS = exports.INPUT_GENERATE_JOB_SUMMARY = exports.INPUT_CACHE_DISABLED = exports.INPUT_CMAKE_VERSION = exports.INPUT_NDK_VERSION = exports.INPUT_BUILD_TOOLS_VERSION = exports.INPUT_SDK_VERSION = void 0;
+exports.ANDROID_SDK_ROOT = exports.ANDROID_HOME_DIR = exports.HOME = exports.COMMANDLINE_TOOLS_WINDOWS_URL = exports.COMMANDLINE_TOOLS_MAC_URL = exports.COMMANDLINE_TOOLS_LINUX_URL = exports.INPUT_JOB_STATUS = exports.INPUT_GENERATE_JOB_SUMMARY = exports.INPUT_CACHE_KEY = exports.INPUT_CACHE_DISABLED = exports.INPUT_CMAKE_VERSION = exports.INPUT_NDK_VERSION = exports.INPUT_BUILD_TOOLS_VERSION = exports.INPUT_SDK_VERSION = void 0;
 const os = __importStar(__nccwpck_require__(2037));
 const path_1 = __importDefault(__nccwpck_require__(1017));
 exports.INPUT_SDK_VERSION = 'sdk-version';
@@ -59811,6 +59815,7 @@ exports.INPUT_BUILD_TOOLS_VERSION = 'build-tools-version';
 exports.INPUT_NDK_VERSION = 'ndk-version';
 exports.INPUT_CMAKE_VERSION = 'cmake-version';
 exports.INPUT_CACHE_DISABLED = 'cache-disabled';
+exports.INPUT_CACHE_KEY = 'cache-key';
 exports.INPUT_GENERATE_JOB_SUMMARY = 'generate-job-summary';
 exports.INPUT_JOB_STATUS = 'job-status';
 // https://developer.android.com/studio#command-tools

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -60585,28 +60585,30 @@ const cache = __importStar(__nccwpck_require__(7799));
 const constants_1 = __nccwpck_require__(9042);
 const cache_1 = __nccwpck_require__(7799);
 const RESTORED_ENTRY_STATE_KEY = 'restoredEntry';
-function generateRestoreKey(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion) {
+function generateRestoreKey(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion, cacheKey) {
+    if (cacheKey)
+        return cacheKey;
     return `${sdkVersion}-${buildToolsVersion}-${ndkVersion}-${cmakeVersion}-v3.1`;
 }
-function restoreCache(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion) {
+function restoreCache(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion, cacheKey) {
     return __awaiter(this, void 0, void 0, function* () {
-        const restoreKey = generateRestoreKey(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion);
+        const restoreKey = generateRestoreKey(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion, cacheKey);
         const restoredEntry = yield cache.restoreCache([constants_1.ANDROID_HOME_DIR], restoreKey);
         if (restoredEntry) {
-            core.info(`Found in cache`);
+            core.info(`Found in cache: ${restoredEntry}`);
         }
         else {
-            core.info(`Not Found cache`);
+            core.info(`Not Found cache: ${restoredEntry}`);
         }
         core.saveState(RESTORED_ENTRY_STATE_KEY, restoredEntry);
         return Promise.resolve(restoredEntry);
     });
 }
 exports.restoreCache = restoreCache;
-function saveCache(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion) {
+function saveCache(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion, cacheKey) {
     return __awaiter(this, void 0, void 0, function* () {
-        const restoreKey = generateRestoreKey(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion);
-        core.info(`caching ...`);
+        const restoreKey = generateRestoreKey(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion, cacheKey);
+        core.info(`caching "${restoreKey}" ...`);
         try {
             const savedEntry = yield cache.saveCache([constants_1.ANDROID_HOME_DIR], restoreKey);
             return Promise.resolve(savedEntry);
@@ -60663,7 +60665,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.ANDROID_SDK_ROOT = exports.ANDROID_HOME_DIR = exports.HOME = exports.COMMANDLINE_TOOLS_WINDOWS_URL = exports.COMMANDLINE_TOOLS_MAC_URL = exports.COMMANDLINE_TOOLS_LINUX_URL = exports.INPUT_JOB_STATUS = exports.INPUT_GENERATE_JOB_SUMMARY = exports.INPUT_CACHE_DISABLED = exports.INPUT_CMAKE_VERSION = exports.INPUT_NDK_VERSION = exports.INPUT_BUILD_TOOLS_VERSION = exports.INPUT_SDK_VERSION = void 0;
+exports.ANDROID_SDK_ROOT = exports.ANDROID_HOME_DIR = exports.HOME = exports.COMMANDLINE_TOOLS_WINDOWS_URL = exports.COMMANDLINE_TOOLS_MAC_URL = exports.COMMANDLINE_TOOLS_LINUX_URL = exports.INPUT_JOB_STATUS = exports.INPUT_GENERATE_JOB_SUMMARY = exports.INPUT_CACHE_KEY = exports.INPUT_CACHE_DISABLED = exports.INPUT_CMAKE_VERSION = exports.INPUT_NDK_VERSION = exports.INPUT_BUILD_TOOLS_VERSION = exports.INPUT_SDK_VERSION = void 0;
 const os = __importStar(__nccwpck_require__(2037));
 const path_1 = __importDefault(__nccwpck_require__(1017));
 exports.INPUT_SDK_VERSION = 'sdk-version';
@@ -60671,6 +60673,7 @@ exports.INPUT_BUILD_TOOLS_VERSION = 'build-tools-version';
 exports.INPUT_NDK_VERSION = 'ndk-version';
 exports.INPUT_CMAKE_VERSION = 'cmake-version';
 exports.INPUT_CACHE_DISABLED = 'cache-disabled';
+exports.INPUT_CACHE_KEY = 'cache-key';
 exports.INPUT_GENERATE_JOB_SUMMARY = 'generate-job-summary';
 exports.INPUT_JOB_STATUS = 'job-status';
 // https://developer.android.com/studio#command-tools
@@ -60732,12 +60735,12 @@ const path = __importStar(__nccwpck_require__(1017));
 const toolCache = __importStar(__nccwpck_require__(7784));
 const constants_1 = __nccwpck_require__(9042);
 const cache_1 = __nccwpck_require__(4810);
-function getAndroidSdk(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion, cacheDisabled) {
+function getAndroidSdk(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion, cacheDisabled, cacheKey) {
     return __awaiter(this, void 0, void 0, function* () {
         if (!cacheDisabled) {
-            const restoreCacheEntry = yield (0, cache_1.restoreCache)(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion);
+            const restoreCacheEntry = yield (0, cache_1.restoreCache)(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion, cacheKey);
             if (restoreCacheEntry) {
-                core.info(`cache hit`);
+                core.info(`cache hit: ${restoreCacheEntry}`);
                 return Promise.resolve();
             }
         }
@@ -60859,13 +60862,15 @@ function run() {
             const ndkVersion = core.getInput(constants.INPUT_NDK_VERSION);
             const cmakeVersion = core.getInput(constants.INPUT_CMAKE_VERSION);
             const cacheDisabled = core.getBooleanInput(constants.INPUT_CACHE_DISABLED);
+            const cacheKey = core.getInput(constants.INPUT_CACHE_KEY);
             core.info(`sdk-version: ${sdkVersion}`);
             core.info(`build-tools-version: ${buildToolsVersion}`);
             core.info(`ndk-version: ${ndkVersion}`);
             core.info(`cmake-version: ${cmakeVersion}`);
             core.info(`cache-disabled: ${cacheDisabled}`);
+            core.info(`cache-key: ${cacheKey}`);
             (0, add_path_1.addPath)();
-            yield (0, installer_1.getAndroidSdk)(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion, cacheDisabled);
+            yield (0, installer_1.getAndroidSdk)(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion, cacheDisabled, cacheKey);
         }
         catch (error) {
             if (error instanceof Error)

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "setup-android",
-  "version": "2",
+  "version": "3",
   "description": "setup-android for self hosted runner",
   "main": "dist/setup/index.js",
   "scripts": {
     "postinstall": "patch-package",
     "build": "tsc",
-    "format": "prettier --write '**/*.ts'",
-    "format-check": "prettier --check '**/*.ts'",
+    "format": "prettier --write **/*.ts",
+    "format-check": "prettier --check **/*.ts",
     "lint": "eslint src/**/*.ts",
     "package": "ncc build -o dist/setup src/setup-android.ts && ncc build -o dist/cleanup src/cleanup-android.ts",
     "all": "npm run postinstall && npm run build && npm run format && npm run lint && npm run package"

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -9,8 +9,10 @@ function generateRestoreKey(
   sdkVersion: string,
   buildToolsVersion: string,
   ndkVersion: string,
-  cmakeVersion: string
+  cmakeVersion: string,
+  cacheKey: string
 ): string {
+  if (cacheKey) return cacheKey
   return `${sdkVersion}-${buildToolsVersion}-${ndkVersion}-${cmakeVersion}-v3.1`
 }
 
@@ -18,20 +20,22 @@ export async function restoreCache(
   sdkVersion: string,
   buildToolsVersion: string,
   ndkVersion: string,
-  cmakeVersion: string
+  cmakeVersion: string,
+  cacheKey: string
 ): Promise<CacheEntry | undefined> {
   const restoreKey = generateRestoreKey(
     sdkVersion,
     buildToolsVersion,
     ndkVersion,
-    cmakeVersion
+    cmakeVersion,
+    cacheKey
   )
 
   const restoredEntry = await cache.restoreCache([ANDROID_HOME_DIR], restoreKey)
   if (restoredEntry) {
-    core.info(`Found in cache`)
+    core.info(`Found in cache: ${restoredEntry}`)
   } else {
-    core.info(`Not Found cache`)
+    core.info(`Not Found cache: ${restoredEntry}`)
   }
   core.saveState(RESTORED_ENTRY_STATE_KEY, restoredEntry)
   return Promise.resolve(restoredEntry)
@@ -41,16 +45,18 @@ export async function saveCache(
   sdkVersion: string,
   buildToolsVersion: string,
   ndkVersion: string,
-  cmakeVersion: string
+  cmakeVersion: string,
+  cacheKey: string
 ): Promise<CacheEntry | undefined> {
   const restoreKey = generateRestoreKey(
     sdkVersion,
     buildToolsVersion,
     ndkVersion,
-    cmakeVersion
+    cmakeVersion,
+    cacheKey
   )
 
-  core.info(`caching ...`)
+  core.info(`caching "${restoreKey}" ...`)
   try {
     const savedEntry = await cache.saveCache([ANDROID_HOME_DIR], restoreKey)
     return Promise.resolve(savedEntry)

--- a/src/cleanup-android.ts
+++ b/src/cleanup-android.ts
@@ -15,11 +15,13 @@ async function run(): Promise<void> {
     const ndkVersion = core.getInput(constants.INPUT_NDK_VERSION)
     const cmakeVersion = core.getInput(constants.INPUT_CMAKE_VERSION)
     const cacheDisabled = core.getBooleanInput(constants.INPUT_CACHE_DISABLED)
+    const cacheKey = core.getInput(constants.INPUT_CACHE_KEY)
     const generateJobSummary = core.getBooleanInput(
       constants.INPUT_GENERATE_JOB_SUMMARY
     )
 
     core.info(`cache-disabled: ${cacheDisabled}`)
+    core.info(`cache-key: ${cacheKey}`)
     core.info(`generate-job-summary: ${generateJobSummary}`)
 
     let savedCacheEntry
@@ -28,7 +30,8 @@ async function run(): Promise<void> {
         sdkVersion,
         buildToolsVersion,
         ndkVersion,
-        cmakeVersion
+        cmakeVersion,
+        cacheKey
       )
     }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,6 +6,7 @@ export const INPUT_BUILD_TOOLS_VERSION = 'build-tools-version'
 export const INPUT_NDK_VERSION = 'ndk-version'
 export const INPUT_CMAKE_VERSION = 'cmake-version'
 export const INPUT_CACHE_DISABLED = 'cache-disabled'
+export const INPUT_CACHE_KEY = 'cache-key'
 
 export const INPUT_GENERATE_JOB_SUMMARY = 'generate-job-summary'
 export const INPUT_JOB_STATUS = 'job-status'

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -16,17 +16,19 @@ export async function getAndroidSdk(
   buildToolsVersion: string,
   ndkVersion: string,
   cmakeVersion: string,
-  cacheDisabled: boolean
+  cacheDisabled: boolean,
+  cacheKey: string
 ): Promise<void> {
   if (!cacheDisabled) {
     const restoreCacheEntry = await restoreCache(
       sdkVersion,
       buildToolsVersion,
       ndkVersion,
-      cmakeVersion
+      cmakeVersion,
+      cacheKey
     )
     if (restoreCacheEntry) {
-      core.info(`cache hit`)
+      core.info(`cache hit: ${restoreCacheEntry}`)
       return Promise.resolve()
     }
   }

--- a/src/setup-android.ts
+++ b/src/setup-android.ts
@@ -10,12 +10,14 @@ async function run(): Promise<void> {
     const ndkVersion = core.getInput(constants.INPUT_NDK_VERSION)
     const cmakeVersion = core.getInput(constants.INPUT_CMAKE_VERSION)
     const cacheDisabled = core.getBooleanInput(constants.INPUT_CACHE_DISABLED)
+    const cacheKey = core.getInput(constants.INPUT_CACHE_KEY)
 
     core.info(`sdk-version: ${sdkVersion}`)
     core.info(`build-tools-version: ${buildToolsVersion}`)
     core.info(`ndk-version: ${ndkVersion}`)
     core.info(`cmake-version: ${cmakeVersion}`)
     core.info(`cache-disabled: ${cacheDisabled}`)
+    core.info(`cache-key: ${cacheKey}`)
 
     addPath()
 
@@ -24,7 +26,8 @@ async function run(): Promise<void> {
       buildToolsVersion,
       ndkVersion,
       cmakeVersion,
-      cacheDisabled
+      cacheDisabled,
+      cacheKey
     )
   } catch (error) {
     if (error instanceof Error) core.setFailed(error.message)


### PR DESCRIPTION
When the user does not disable the use of cache (cache-disabled:true), the user can customize the cache key.

For example: https://github.com/wtto00/karma-android-launcher/actions/runs/6380253195/workflow

Here I am running 14 tasks simultaneously, and each task will execute the following shell commands:
```shell
# Install emulator tool
sdkmanager --install emulator
# The android-31 in each task is different, ranging from android-21 to android-34
sdkmanager --install "system-images;android-31;default;x86_64"
# Create emulator
avdmanager -s create avd -n android_emulator_name -k "system-images;android-31;default;x86_64"
# Start emulator
emulator -avd android_emulator_name -no-window -noaudio
```
However, all the cache keys for these tasks are the same, so the cache for the 'system-images' I installed is not saved, or only one of them is cached. They will overwrite each other.

In addition, each task will create an emulator, which is a time-consuming task to create and launch the emulator from scratch. If it can be cached, it will be much faster.

If it is possible to customize the cache key, all the data for different tasks can be cached, and the next execution will be much faster. It won't need to download and create the emulator from scratch every time.