### PR TITLE
fix: some minor repairs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,7 +144,7 @@ jobs:
       - name: Setup Android SDK
         uses: ./
         with:
-          cache-key: 'default-version'
+          cache-key: custom-cache-key-on-${{matrix.os}}
 
       - run: |
           sdkmanager --install emulator

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ steps:
       # Whether to use the cache
       cache-disabled: true
 
-      # default: `${sdkVersion}-${buildToolsVersion}-${ndkVersion}-${cmakeVersion}-v3.1`
+      # default: `${sdkVersion}-${buildToolsVersion}-${ndkVersion}-${cmakeVersion}-v3.2`
       # Custom key for cache. It is invalid when `cache-disabled: true`
       cache-key: 'custom-cache-key'
 

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -59646,17 +59646,17 @@ const RESTORED_ENTRY_STATE_KEY = 'restoredEntry';
 function generateRestoreKey(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion, cacheKey) {
     if (cacheKey)
         return cacheKey;
-    return `${sdkVersion}-${buildToolsVersion}-${ndkVersion}-${cmakeVersion}-v3.1`;
+    return `${sdkVersion}-${buildToolsVersion}-${ndkVersion}-${cmakeVersion}-v3.2`;
 }
 function restoreCache(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion, cacheKey) {
     return __awaiter(this, void 0, void 0, function* () {
         const restoreKey = generateRestoreKey(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion, cacheKey);
         const restoredEntry = yield cache.restoreCache([constants_1.ANDROID_HOME_DIR], restoreKey);
         if (restoredEntry) {
-            core.info(`Found in cache: ${restoredEntry}`);
+            core.info(`Found in cache: ${restoreKey}`);
         }
         else {
-            core.info(`Not Found cache: ${restoredEntry}`);
+            core.info(`Not Found cache: ${restoreKey}`);
         }
         core.saveState(RESTORED_ENTRY_STATE_KEY, restoredEntry);
         return Promise.resolve(restoredEntry);

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -60588,17 +60588,17 @@ const RESTORED_ENTRY_STATE_KEY = 'restoredEntry';
 function generateRestoreKey(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion, cacheKey) {
     if (cacheKey)
         return cacheKey;
-    return `${sdkVersion}-${buildToolsVersion}-${ndkVersion}-${cmakeVersion}-v3.1`;
+    return `${sdkVersion}-${buildToolsVersion}-${ndkVersion}-${cmakeVersion}-v3.2`;
 }
 function restoreCache(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion, cacheKey) {
     return __awaiter(this, void 0, void 0, function* () {
         const restoreKey = generateRestoreKey(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion, cacheKey);
         const restoredEntry = yield cache.restoreCache([constants_1.ANDROID_HOME_DIR], restoreKey);
         if (restoredEntry) {
-            core.info(`Found in cache: ${restoredEntry}`);
+            core.info(`Found in cache: ${restoreKey}`);
         }
         else {
-            core.info(`Not Found cache: ${restoredEntry}`);
+            core.info(`Not Found cache: ${restoreKey}`);
         }
         core.saveState(RESTORED_ENTRY_STATE_KEY, restoredEntry);
         return Promise.resolve(restoredEntry);
@@ -60740,7 +60740,7 @@ function getAndroidSdk(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion, 
         if (!cacheDisabled) {
             const restoreCacheEntry = yield (0, cache_1.restoreCache)(sdkVersion, buildToolsVersion, ndkVersion, cmakeVersion, cacheKey);
             if (restoreCacheEntry) {
-                core.info(`cache hit: ${restoreCacheEntry}`);
+                core.info(`cache hit: ${restoreCacheEntry.key}`);
                 return Promise.resolve();
             }
         }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -33,9 +33,9 @@ export async function restoreCache(
 
   const restoredEntry = await cache.restoreCache([ANDROID_HOME_DIR], restoreKey)
   if (restoredEntry) {
-    core.info(`Found in cache: ${restoredEntry}`)
+    core.info(`Found in cache: ${restoreKey}`)
   } else {
-    core.info(`Not Found cache: ${restoredEntry}`)
+    core.info(`Not Found cache: ${restoreKey}`)
   }
   core.saveState(RESTORED_ENTRY_STATE_KEY, restoredEntry)
   return Promise.resolve(restoredEntry)

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -13,7 +13,7 @@ function generateRestoreKey(
   cacheKey: string
 ): string {
   if (cacheKey) return cacheKey
-  return `${sdkVersion}-${buildToolsVersion}-${ndkVersion}-${cmakeVersion}-v3.1`
+  return `${sdkVersion}-${buildToolsVersion}-${ndkVersion}-${cmakeVersion}-v3.2`
 }
 
 export async function restoreCache(

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -28,7 +28,7 @@ export async function getAndroidSdk(
       cacheKey
     )
     if (restoreCacheEntry) {
-      core.info(`cache hit: ${restoreCacheEntry}`)
+      core.info(`cache hit: ${restoreCacheEntry.key}`)
       return Promise.resolve()
     }
   }


### PR DESCRIPTION
- In test of CI, configure custom cache key based on the matrix variable.
- Fixing cache printing log, [object Object] appeared.

This can be postponed for release and can be published with the changes in the next version.