### PR TITLE
[codex] Update codename SDK CI job to CinnamonBun

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -261,8 +261,8 @@ jobs:
       - run: |
           sdkmanager --list_installed
 
-  test_Baklava:
-    name: run test ${{ matrix.os }} sdkversion Baklava
+  test_CinnamonBun:
+    name: run test ${{ matrix.os }} sdkversion CinnamonBun
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     strategy:
@@ -270,7 +270,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-Baklava-test
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-CinnamonBun-test
       cancel-in-progress: true
 
     steps:
@@ -298,7 +298,7 @@ jobs:
         uses: ./
         with:
           cache-disabled: false
-          sdk-version: Baklava
+          sdk-version: CinnamonBun
 
       - run: |
           ./sample-android-project/gradlew -p sample-android-project assembleDebug --stacktrace

--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ If your project uses VersionCatalog, the following settings are recommended
       sdk-version: |
         35
         36
-      # or set sdk-version to the value written in API Level from SDK Manager
-      sdk-version: Baklava
+      # or set sdk-version to a codename-based platform package from SDK Manager
+      sdk-version: CinnamonBun
 
       # default: ''
       # build tools version


### PR DESCRIPTION
## Summary

Replace the obsolete `test_Baklava` GitHub Actions job with `test_CinnamonBun`, and update the README codename example to `CinnamonBun`.

## Root cause

The open Renovate PRs are blocked by the same three failing jobs: `run test <os> sdkversion Baklava`. The latest Android SDK repository no longer exposes the old `platforms;android-Baklava` package. The current codename-based platform package is `platforms;android-CinnamonBun`, with API level `37.0`.

## Validation

- Confirmed `repository2-3.xml` contains `platforms;android-CinnamonBun`
- `git diff --check`
- Ruby YAML parse of `.github/workflows/test.yml`
- `npm run lint` with Node 24.14.0

## Follow-up

After this lands, rerun or rebase the open Renovate PRs so they pick up the fixed workflow.
