### PR TITLE
Improve error guidance for codename SDK versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -177,6 +177,38 @@ jobs:
       - run: |
           sdkmanager --list_installed | grep "platforms;android-37.0"
 
+  test_removed_codename_sdk_version_error:
+    name: run test removed codename sdk version error
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup JDK 17
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
+        with:
+          java-version: 17
+          distribution: jetbrains
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify removed codename SDK version error
+        shell: bash
+        run: |
+          set +e
+          env \
+            'INPUT_SDK-VERSION=CinnamonBun' \
+            'INPUT_CACHE-DISABLED=true' \
+            'INPUT_COMMAND-LINE-TOOLS-VERSION=14742923' \
+            node dist/setup/index.js 2>&1 | tee "$RUNNER_TEMP/setup-android.log"
+          status=${PIPESTATUS[0]}
+          set -e
+
+          test "$status" -ne 0
+          grep -F 'codename-based Android SDK platform "platforms;android-CinnamonBun"' \
+            "$RUNNER_TEMP/setup-android.log"
+
   test_custom_cache_key:
     name: run test custom cache key ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -76733,7 +76733,23 @@ async function installAndroidSdk(versions) {
     else {
         info(`start install platform-tools and sdk:${versions.sdkVersion} (build-tools skipped)`);
     }
-    await exec('sdkmanager', packages, { silent: !isDebug() });
+    try {
+        await exec('sdkmanager', packages, { silent: !isDebug() });
+    }
+    catch (error) {
+        const codenamePackages = versions.sdkVersion
+            .filter(version => !/^\d+(?:\.\d+)?$/.test(version))
+            .map(version => `"platforms;android-${version}"`);
+        if (codenamePackages.length === 0) {
+            throw error;
+        }
+        const originalError = error instanceof Error ? ` Original error: ${error.message}` : '';
+        throw new Error('sdkmanager failed while installing packages that include the ' +
+            `codename-based Android SDK platform ${codenamePackages.join(', ')}. ` +
+            'Verify that the package ID is still listed by "sdkmanager --list", ' +
+            'then set "sdk-version" to an available exact suffix (for example, ' +
+            `"37.0").${originalError}`);
+    }
     if (versions.buildToolsVersion.length > 0) {
         info(`success install build-tools:${versions.buildToolsVersion} and platform-tools and sdk:${versions.sdkVersion}`);
     }

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -127,7 +127,27 @@ export async function installAndroidSdk(versions: Versions): Promise<void> {
       `start install platform-tools and sdk:${versions.sdkVersion} (build-tools skipped)`
     )
   }
-  await exec.exec('sdkmanager', packages, {silent: !core.isDebug()})
+  try {
+    await exec.exec('sdkmanager', packages, {silent: !core.isDebug()})
+  } catch (error) {
+    const codenamePackages = versions.sdkVersion
+      .filter(version => !/^\d+(?:\.\d+)?$/.test(version))
+      .map(version => `"platforms;android-${version}"`)
+
+    if (codenamePackages.length === 0) {
+      throw error
+    }
+
+    const originalError =
+      error instanceof Error ? ` Original error: ${error.message}` : ''
+    throw new Error(
+      'sdkmanager failed while installing packages that include the ' +
+        `codename-based Android SDK platform ${codenamePackages.join(', ')}. ` +
+        'Verify that the package ID is still listed by "sdkmanager --list", ' +
+        'then set "sdk-version" to an available exact suffix (for example, ' +
+        `"37.0").${originalError}`
+    )
+  }
   if (versions.buildToolsVersion.length > 0) {
     core.info(
       `success install build-tools:${versions.buildToolsVersion} and platform-tools and sdk:${versions.sdkVersion}`


### PR DESCRIPTION
## Summary

When `sdkmanager` fails while installing a codename-based Android SDK platform, the action now explains how to verify the exact package ID that is currently available.

## Background

`CinnamonBun` was silently removed from Google's SDK repository. The previous error did not make it clear that the configured `sdk-version` was no longer available.

## Changes

- Wrap only the existing `sdkmanager` invocation in `try-catch`; do not run an additional `sdkmanager --list`
- Preserve the original error for numeric SDK versions
- For codename-based versions, suggest checking `sdkmanager --list` for the exact package ID
- Add a CI job that uses the removed `CinnamonBun` package to verify both the failure and the improved error message

## Verification

- `pnpm run all`
- Workflow YAML syntax check
- All 38 CI checks passed
- Confirmed that the CI log contains `codename-based Android SDK platform "platforms;android-CinnamonBun"`