### PR TITLE
Group Biome updates into one Renovate PR

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -22,5 +22,13 @@
         'com.android.application{/,}**',
       ],
     },
+    {
+      groupName: 'Biome',
+      groupSlug: 'biome',
+      groupSingleUpdates: true,
+      matchDepNames: [
+        '@biomejs/biome',
+      ],
+    },
   ],
 }


### PR DESCRIPTION
## Summary

- group Renovate updates for `@biomejs/biome` under a shared group
- use a stable `biome` group slug and apply the group settings to single updates

## Why

Renovate currently detects the Biome schema and pnpm lockfile through separate managers, which creates two pull requests for the same Biome release. Grouping both dependency entries keeps each Biome release in one pull request.

## Impact

Future Biome schema and lockfile updates will be proposed together, reducing duplicate pull requests and CI runs.

## Validation

- `renovate-config-validator renovate.json5` with Renovate 43.277.0
- `git diff --check`