### PR TITLE
Keep Node.js runtime versions in sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
     "typescript": "npm:@typescript/typescript6@6.0.2"
   },
   "engines": {
-    "node": ">=24.0.0"
+    "node": "24.18.0"
   }
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -36,5 +36,17 @@
         '@biomejs/biome',
       ],
     },
+    {
+      groupName: 'Node.js',
+      matchDatasources: [
+        'node-version',
+      ],
+      matchDepNames: [
+        'node',
+      ],
+      ignoreUnstable: true,
+      rangeStrategy: 'pin',
+      versioning: 'node',
+    },
   ],
 }


### PR DESCRIPTION
## Summary

- pin `engines.node` to the version in `.node-version`
- group Node.js updates from `package.json` and `.node-version` into the same Renovate branch
- explicitly use Renovate's Node.js versioning so new major releases are proposed only after they reach LTS

## Why

Renovate PR #804 attempted to pin the open-ended `engines.node` range to Node.js 26 while `.node-version` remained on Node.js 24 LTS. Keeping both values pinned to the same release gives Renovate identical inputs, and grouping the `node-version` datasource keeps future updates atomic across both files.

## Validation

- `renovate-config-validator renovate.json5`
- Renovate local lookup confirmed both files resolve from `24.18.0` to `24.18.1` on `renovate/node.js`
- verified `package.json#engines.node` matches `.node-version`