### PR TITLE
Automate dist regeneration for Rolldown updates

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -12,6 +12,16 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number used for concurrency
+        required: true
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.pr_number || github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -22,6 +32,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,15 @@
 name: 'lint'
 on:
   pull_request:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number used for concurrency
+        required: true
+        type: string
+
+permissions:
+  contents: read
 
 jobs:
   test:
@@ -8,11 +17,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: ${{ github.workflow }}-${{ inputs.pr_number || github.event.pull_request.number || github.ref }}
       cancel-in-progress: true
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,15 @@
 name: build-test
 on:
   pull_request:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number used for concurrency
+        required: true
+        type: string
+
+permissions:
+  contents: read
 
 jobs:
   test:
@@ -13,11 +22,14 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         sdk: [35, 36, "37.0"]
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-${{ matrix.sdk }}-test
+      group: ${{ github.workflow }}-${{ inputs.pr_number || github.event.pull_request.number || github.ref }}-${{ matrix.os }}-${{ matrix.sdk }}-test
       cancel-in-progress: true
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
 
       - name: remove android sdk from ubuntu-latest
         shell: bash
@@ -58,11 +70,14 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-test_not_use_cache
+      group: ${{ github.workflow }}-${{ inputs.pr_number || github.event.pull_request.number || github.ref }}-${{ matrix.os }}-test_not_use_cache
       cancel-in-progress: true
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
 
       - name: remove android sdk from ubuntu-latest
         shell: bash
@@ -103,11 +118,14 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-test_check_cmdline_tools_path
+      group: ${{ github.workflow }}-${{ inputs.pr_number || github.event.pull_request.number || github.ref }}-${{ matrix.os }}-test_check_cmdline_tools_path
       cancel-in-progress: true
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
 
       - name: remove android sdk from ubuntu-latest
         shell: bash
@@ -144,11 +162,14 @@ jobs:
       matrix:
         sdk: [37, "37.0"]
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.sdk }}-test_android_minor_sdk_version
+      group: ${{ github.workflow }}-${{ inputs.pr_number || github.event.pull_request.number || github.ref }}-${{ matrix.sdk }}-test_android_minor_sdk_version
       cancel-in-progress: true
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
 
       - name: remove android sdk from ubuntu-latest
         shell: bash
@@ -181,9 +202,15 @@ jobs:
     name: run test unavailable codename sdk version error
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    concurrency:
+      group: ${{ github.workflow }}-${{ inputs.pr_number || github.event.pull_request.number || github.ref }}-test_unavailable_codename_sdk_version_error
+      cancel-in-progress: true
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
 
       - name: Setup JDK 17
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
@@ -220,11 +247,14 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-test_custom_cache_key
+      group: ${{ github.workflow }}-${{ inputs.pr_number || github.event.pull_request.number || github.ref }}-${{ matrix.os }}-test_custom_cache_key
       cancel-in-progress: true
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
 
       - name: remove android sdk from ubuntu-latest
         shell: bash
@@ -261,11 +291,14 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-test_install_multiple_sdk_version
+      group: ${{ github.workflow }}-${{ inputs.pr_number || github.event.pull_request.number || github.ref }}-${{ matrix.os }}-test_install_multiple_sdk_version
       cancel-in-progress: true
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
 
       - name: remove android sdk from ubuntu-latest
         shell: bash
@@ -305,11 +338,14 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         command-line-tools-version: [13114758, 12266719, 11479570]
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-${{ matrix.command-line-tools-version }}-test_command_line_tools_version
+      group: ${{ github.workflow }}-${{ inputs.pr_number || github.event.pull_request.number || github.ref }}-${{ matrix.os }}-${{ matrix.command-line-tools-version }}-test_command_line_tools_version
       cancel-in-progress: true
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
 
       - name: remove android sdk from ubuntu-latest
         shell: bash
@@ -352,11 +388,14 @@ jobs:
             node_architecture: arm64
             expected_url: https://dl.google.com/android/repository/commandlinetools-mac_arm64-15859902_latest.zip
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-test_command_line_tools_mac_architecture
+      group: ${{ github.workflow }}-${{ inputs.pr_number || github.event.pull_request.number || github.ref }}-${{ matrix.os }}-test_command_line_tools_mac_architecture
       cancel-in-progress: true
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
 
       - name: Remove preinstalled Android SDK
         shell: bash
@@ -408,11 +447,14 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.os }}-test_install_multiple_build_tools_version
+      group: ${{ github.workflow }}-${{ inputs.pr_number || github.event.pull_request.number || github.ref }}-${{ matrix.os }}-test_install_multiple_build_tools_version
       cancel-in-progress: true
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
 
       - name: remove android sdk from ubuntu-latest
         shell: bash

--- a/.github/workflows/update-renovate-dist.yml
+++ b/.github/workflows/update-renovate-dist.yml
@@ -1,8 +1,5 @@
 name: Update Renovate dist
 
-# Add a RENOVATE_DIST_TOKEN repository secret containing a fine-grained
-# personal access token with Contents read/write access so pushes rerun CI.
-
 on:
   pull_request:
     types: [opened, reopened, synchronize]
@@ -68,6 +65,9 @@ jobs:
           path: dist/
           retention-days: 1
 
+  # GITHUB_TOKEN pushes do not start another workflow run. The read-only build
+  # job therefore performs the complete lint, typecheck, and package validation
+  # before this write-enabled job commits its artifact.
   update:
     needs: build
     if: needs.build.outputs.changed == 'true'
@@ -76,22 +76,10 @@ jobs:
       contents: write
 
     steps:
-      - name: Require update token
-        shell: bash
-        env:
-          RENOVATE_DIST_TOKEN: ${{ secrets.RENOVATE_DIST_TOKEN }}
-        run: |
-          if [ -z "$RENOVATE_DIST_TOKEN" ]; then
-            echo "The RENOVATE_DIST_TOKEN repository secret is required."
-            echo "Use a fine-grained personal access token with Contents read/write access."
-            exit 1
-          fi
-
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
-          token: ${{ secrets.RENOVATE_DIST_TOKEN }}
 
       - name: Verify pull request head
         shell: bash

--- a/.github/workflows/update-renovate-dist.yml
+++ b/.github/workflows/update-renovate-dist.yml
@@ -19,8 +19,8 @@ permissions:
 jobs:
   build:
     if: >-
-      github.actor == 'renovate[bot]' &&
       github.event.pull_request.user.login == 'renovate[bot]' &&
+      github.event.pull_request.user.id == 29139614 &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       startsWith(github.event.pull_request.head.ref, 'renovate/rolldown-')
     runs-on: ubuntu-latest
@@ -77,6 +77,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
+          persist-credentials: true
 
       - name: Verify pull request head
         shell: bash

--- a/.github/workflows/update-renovate-dist.yml
+++ b/.github/workflows/update-renovate-dist.yml
@@ -1,7 +1,8 @@
 name: Update Renovate dist
 
 on:
-  pull_request:
+  # The PR checkout runs only in a read-only job; the write job never executes it.
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
     types: [opened, reopened, synchronize]
     branches:
       - main
@@ -31,12 +32,64 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
           persist-credentials: false
+
+      - name: Verify changed paths
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          unexpected_paths=()
+          while IFS= read -r -d '' path; do
+            case "$path" in
+              package.json|pnpm-lock.yaml|dist/*) ;;
+              *) unexpected_paths+=("$path") ;;
+            esac
+          done < <(git diff --name-only --no-renames -z "$BASE_SHA...HEAD")
+
+          if [ "${#unexpected_paths[@]}" -ne 0 ]; then
+            echo "Unexpected files in the Rolldown update:"
+            printf '  %q\n' "${unexpected_paths[@]}"
+            exit 1
+          fi
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .node-version
+
+      - name: Verify Rolldown-only manifest change
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          node --input-type=module <<'EOF'
+          import assert from 'node:assert/strict';
+          import { execFileSync } from 'node:child_process';
+          import { readFileSync } from 'node:fs';
+
+          const base = JSON.parse(
+            execFileSync('git', ['show', `${process.env.BASE_SHA}:package.json`], {
+              encoding: 'utf8',
+            }),
+          );
+          const head = JSON.parse(readFileSync('package.json', 'utf8'));
+          const baseRolldown = base.devDependencies?.rolldown;
+          const headRolldown = head.devDependencies?.rolldown;
+
+          assert.equal(typeof baseRolldown, 'string');
+          assert.equal(typeof headRolldown, 'string');
+          assert.notEqual(headRolldown, baseRolldown, 'Rolldown must be updated');
+
+          delete base.devDependencies.rolldown;
+          delete head.devDependencies.rolldown;
+          assert.deepEqual(
+            head,
+            base,
+            'Only the Rolldown version may change in package.json',
+          );
+          EOF
 
       - name: Enable Corepack
         run: corepack enable
@@ -70,7 +123,8 @@ jobs:
     if: needs.build.outputs.changed == 'true'
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      actions: write # Dispatch validation for the generated commit.
+      contents: write # Push the generated dist files.
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -100,6 +154,8 @@ jobs:
         shell: bash
         env:
           HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -112,3 +168,10 @@ jobs:
 
           git commit -m "Regenerate dist for Rolldown update"
           git push origin "HEAD:$HEAD_BRANCH"
+
+          for workflow in check-dist.yml lint.yml test.yml; do
+            gh api --method POST \
+              "repos/$GITHUB_REPOSITORY/actions/workflows/$workflow/dispatches" \
+              -f "ref=$HEAD_BRANCH" \
+              -f "inputs[pr_number]=$PR_NUMBER"
+          done

--- a/.github/workflows/update-renovate-dist.yml
+++ b/.github/workflows/update-renovate-dist.yml
@@ -1,0 +1,128 @@
+name: Update Renovate dist
+
+# Add a RENOVATE_DIST_TOKEN repository secret containing a fine-grained
+# personal access token with Contents read/write access so pushes rerun CI.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches:
+      - main
+    paths:
+      - package.json
+      - pnpm-lock.yaml
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    if: >-
+      github.actor == 'renovate[bot]' &&
+      github.event.pull_request.user.login == 'renovate[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      startsWith(github.event.pull_request.head.ref, 'renovate/rolldown-')
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.diff.outputs.changed }}
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .node-version
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Rebuild dist
+        run: pnpm run all
+
+      - name: Check generated files
+        id: diff
+        shell: bash
+        run: |
+          if git diff --quiet -- dist/; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload generated dist
+        if: steps.diff.outputs.changed == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: renovate-dist-${{ github.run_id }}
+          path: dist/
+          retention-days: 1
+
+  update:
+    needs: build
+    if: needs.build.outputs.changed == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Require update token
+        shell: bash
+        env:
+          RENOVATE_DIST_TOKEN: ${{ secrets.RENOVATE_DIST_TOKEN }}
+        run: |
+          if [ -z "$RENOVATE_DIST_TOKEN" ]; then
+            echo "The RENOVATE_DIST_TOKEN repository secret is required."
+            echo "Use a fine-grained personal access token with Contents read/write access."
+            exit 1
+          fi
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+          token: ${{ secrets.RENOVATE_DIST_TOKEN }}
+
+      - name: Verify pull request head
+        shell: bash
+        env:
+          EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [ "$(git rev-parse HEAD)" != "$EXPECTED_HEAD_SHA" ]; then
+            echo "The pull request branch changed while dist was being generated."
+            echo "A newer workflow run will regenerate dist for the new head."
+            exit 1
+          fi
+
+      - name: Download generated dist
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: renovate-dist-${{ github.run_id }}
+          path: dist/
+
+      - name: Commit generated dist
+        shell: bash
+        env:
+          HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add dist/
+
+          if git diff --cached --quiet; then
+            echo "Generated dist is already up to date."
+            exit 0
+          fi
+
+          git commit -m "Regenerate dist for Rolldown update"
+          git push origin "HEAD:$HEAD_BRANCH"

--- a/.github/workflows/update-renovate-dist.yml
+++ b/.github/workflows/update-renovate-dist.yml
@@ -65,9 +65,6 @@ jobs:
           path: dist/
           retention-days: 1
 
-  # GITHUB_TOKEN pushes do not start another workflow run. The read-only build
-  # job therefore performs the complete lint, typecheck, and package validation
-  # before this write-enabled job commits its artifact.
   update:
     needs: build
     if: needs.build.outputs.changed == 'true'

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "oxlint ./src/ && pnpm run format-check",
     "lint-fix": "oxlint --fix ./src/ && pnpm run format",
     "typecheck": "tsc --project tsconfig.json --pretty --noEmit --incremental false",
-    "package": "pnpm dlx rimraf ./dist && pnpm run typecheck && rolldown --config rolldown.config.ts",
+    "package": "node --eval \"require('node:fs').rmSync('dist', { recursive: true, force: true })\" && pnpm run typecheck && rolldown --config rolldown.config.ts",
     "all": "pnpm run postinstall && pnpm run lint && pnpm run package"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "oxlint ./src/ && pnpm run format-check",
     "lint-fix": "oxlint --fix ./src/ && pnpm run format",
     "typecheck": "tsc --project tsconfig.json --pretty --noEmit --incremental false",
-    "package": "node --eval \"require('node:fs').rmSync('dist', { recursive: true, force: true })\" && pnpm run typecheck && rolldown --config rolldown.config.ts",
+    "package": "pnpm dlx rimraf ./dist && pnpm run typecheck && rolldown --config rolldown.config.ts",
     "all": "pnpm run postinstall && pnpm run lint && pnpm run package"
   },
   "repository": {

--- a/renovate.json5
+++ b/renovate.json5
@@ -21,6 +21,15 @@
       ],
     },
     {
+      automerge: false,
+      matchManagers: [
+        'npm',
+      ],
+      matchPackageNames: [
+        'rolldown',
+      ],
+    },
+    {
       groupName: 'Android Gradle Plugin',
       matchPackageNames: [
         'com.android.library{/,}**',


### PR DESCRIPTION
## Summary

- rebuild checked-in `dist/` files automatically for Rolldown Renovate updates
- validate the generated commit with the existing dist, lint, and Android test workflows
- keep Rolldown updates subject to manual review and merge

## Why

Rolldown updates can change bundled output even when application source files do not change. Renovate updates `package.json` and `pnpm-lock.yaml`, but it does not regenerate `dist/`, so `check-dist` fails and requires a manual build commit.

A commit pushed with the repository `GITHUB_TOKEN` does not trigger the normal pull request workflows. Without an explicit follow-up, checks remain associated with the pre-generation commit and the production bundle is not tested.

## Flow

1. A base-controlled `pull_request_target` workflow accepts only same-repository pull requests created by the Renovate GitHub App account on a `renovate/rolldown-*` branch.
2. A read-only job verifies the changed-path allowlist and confirms that Rolldown is the only `package.json` change, then rebuilds `dist/` without persisted Git credentials.
3. If the bundle changes, a separate write job verifies that the pull request head has not moved, commits only `dist/`, and pushes it with the repository `GITHUB_TOKEN`.
4. The write job dispatches `check-dist.yml`, `lint.yml`, and `test.yml` for the updated branch. Those runs test the dispatch event SHA, and shared per-PR concurrency cancels checks for the pre-generation commit.

No personal access token or additional repository secret is required.

## Security

- The privileged workflow definition comes from the base branch, not the pull request branch.
- Unexpected changed paths are rejected; only `package.json`, `pnpm-lock.yaml`, and generated `dist/` files are accepted.
- The manifest guard rejects changes to scripts or dependencies other than Rolldown.
- Dependency and generated code runs only in the job with `contents: read`; the write job never executes it.
- Dispatched validation workflows use `contents: read`, do not persist checkout credentials, and always test their own `github.sha` instead of accepting a caller-selected commit SHA.
- GitHub Actions are pinned to full commit SHAs.
- The Renovate account is checked by both login and immutable account ID.
- Pull request values reach shell scripts through quoted environment variables.
- Rolldown updates are excluded from patch automerge and require a manual merge decision.

The remaining trust boundary is the Rolldown package and its resolved lockfile. The generated bundle therefore remains visible for human review before merge.

## Validation

- `actionlint` 1.7.12
- `zizmor` 1.29.0 with online audits: no unsuppressed low-or-higher findings in the affected workflows
- `pnpm run all` with Node.js 24.19.0 and pnpm 11.20.0
- path and manifest guards exercised against Rolldown PR #824
- `git diff --check`

The live dispatch path can only be exercised after these workflow definitions are present on the default branch, as required by [`workflow_dispatch`](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_dispatch).