### PR TITLE
Use a separate branch prefix for self-hosted Renovate

### DIFF
--- a/.github/renovate-config.json
+++ b/.github/renovate-config.json
@@ -1,6 +1,7 @@
 {
   "platform": "github",
   "repositories": ["amyu/setup-android"],
+  "branchPrefix": "renovate-self-hosted/",
   "onboarding": false,
   "requireConfig": "required",
   "binarySource": "install",

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -31,7 +31,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.RENOVATE_APP_ID }}
+          client-id: ${{ vars.RENOVATE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: setup-android


### PR DESCRIPTION
Use `renovate-self-hosted/` for branches created by the self-hosted Renovate workflow. The previous default `renovate/` prefix collides with branches left by the Mend-hosted App, preventing the new GitHub App from rebuilding the existing Rolldown update with generated `dist/**` artifacts. Use the GitHub App Client ID instead of the deprecated numeric App ID when creating installation tokens.

After merging, run the Renovate workflow without dry-run. It should create a replacement Rolldown PR under the new prefix; the old Mend PR can then be closed.

Validation: Renovate 44.65.5 configuration validation, actionlint, and `git diff --check` passed. Local validation emitted the existing RE2 fallback warning.
