### PR TITLE
Adopt Renovate pull requests created by the hosted app

### DIFF
--- a/.github/renovate-config.json
+++ b/.github/renovate-config.json
@@ -1,7 +1,7 @@
 {
   "platform": "github",
   "repositories": ["amyu/setup-android"],
-  "branchPrefix": "renovate-self-hosted/",
+  "ignorePrAuthor": true,
   "onboarding": false,
   "requireConfig": "required",
   "binarySource": "install",


### PR DESCRIPTION
Configure self-hosted Renovate to fetch pull requests created by the previous Mend-hosted bot. Without `ignorePrAuthor`, the new GitHub App cannot find and update the existing Rolldown PR, so its requested rebase and `postUpgradeTasks` rebuild are skipped.

Restore the default `renovate/` branch prefix now that the Mend App has been removed. After merging, rerun Renovate to adopt and rebuild PR #841 with the generated `dist/**` artifacts.

Validation: Renovate 44.65.5 configuration validation and `git diff --check` passed. Local validation emitted the existing RE2 fallback warning.
