### PR TITLE
Remove Renovate dry-run input

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -4,11 +4,6 @@ on:
   schedule:
     - cron: '23 */3 * * *'
   workflow_dispatch:
-    inputs:
-      dry-run:
-        description: Preview updates without changing branches or pull requests
-        type: boolean
-        default: true
 
 permissions:
   contents: read
@@ -42,5 +37,3 @@ jobs:
           configurationFile: .github/renovate-config.json
           renovate-version: 44.65.5
           token: ${{ steps.app-token.outputs.token }}
-        env:
-          RENOVATE_DRY_RUN: ${{ inputs.dry-run && 'full' || '' }}


### PR DESCRIPTION
Remove the manual dry-run input and run manual Renovate dispatches with the same live behavior as scheduled runs.

Validation: parsed the workflow as YAML and ran git diff --check.